### PR TITLE
Add instructions for using Codespaces to host the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@
 3. Scroll down to the "GitHub Pages" section.
 4. Select the source branch and directory (root or `docs`) for your site.
 5. Save the settings, and your site will be hosted at `https://<username>.github.io/<repository-name>/`.
+
+## Using Codespaces to Host the Site
+
+1. Open your repository in GitHub and click on the "Code" button.
+2. Select "Open with Codespaces" and create a new Codespace.
+3. In the Codespace, open the terminal and navigate to the directory containing your HTML and CSS files.
+4. Use a simple web server to host your files. For example, you can use Python's built-in HTTP server by running `python -m http.server` in the terminal.
+5. Your site will be accessible at the URL provided by the Codespace.


### PR DESCRIPTION
Add a section on using Codespaces to host the site in `README.md`.

* **Using Codespaces to Host the Site**
  - Add steps to open the repository in Codespaces.
  - Add steps to use a simple web server to host files.
  - Add steps to access the site via the Codespace URL.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/crimecrypto/xyz/pull/3?shareId=4f59621b-69c7-4237-9a81-988416a8e9ea).